### PR TITLE
cuda-toolkit v12.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,15 @@ source:
 
 build:
   number: 0
-  noarch: generic
+  # This is 'technically' not a noarch package: only supported on linux-64, linux-aarch64 and windows-64
+  # Therefore, 'noarch: generic' is replaced with 'skip: true' to avoid building on unsupported platforms.
+  skip: true  # [osx]
 
 requirements:
   run:
-    - __linux  # [linux]
-    - __win    # [win]
+    # Remove '__linux' and '__win' as they might not be handled properly on PBP
+    # Also, see above note about 'skip: true'
+    # Ref: https://docs.conda.io/projects/conda/en/stable/user-guide/tasks/manage-virtual.html
     - cuda-compiler {{ version }}
     - cuda-libraries {{ version }}
     - cuda-libraries-dev {{ version }}
@@ -31,10 +34,12 @@ about:
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Meta-package containing all toolkit packages for CUDA development
   description: |
     Meta-package containing all toolkit packages for CUDA development
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-toolkit 12.9.1

**Destination channel:** defaults

### Links

- [PKG-12809](https://anaconda.atlassian.net/browse/PKG-12809) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-tools-feedstock/pull/6

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's conda-forge/cuda-toolkit-feedstock@8b67f7f17de7f0ac8654a6ed0ea51de8940f692f commit.
- This is a meta-package


[PKG-12809]: https://anaconda.atlassian.net/browse/PKG-12809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ